### PR TITLE
Generate a list of participants as plaintext

### DIFF
--- a/node-w3capi/README.md
+++ b/node-w3capi/README.md
@@ -31,4 +31,8 @@ Output can be found in `data` directory.
 
 ### participants.html
 
+### participants.txt
+
+A snapshot of CG participants (humans) as plaintext
+
 ### users.json

--- a/node-w3capi/index.js
+++ b/node-w3capi/index.js
@@ -39,6 +39,7 @@ const filenames = {
     designated: "affiliation-designated-voters.md",
   },
   txt: {
+    participants: "participants.txt",
     voters: "eligible-voters.txt",
   },
 };
@@ -115,6 +116,12 @@ if (nonSingularOrgs.length === 0) {
   fs.writeFileSync(paths.md.default, markdown);
   spinner.succeed("Generated markdown");
 }
+
+spinner.start("🤖 Generating TXT");
+const participants = data.users.map((user) => user.name);
+participants.sort(alphaSort);
+fs.writeFileSync(paths.txt.participants, participants.join("\n") + "\n");
+spinner.succeed("Generated TXT");
 
 if (localDataExists(paths.md)) {
   spinner.start("🤖 Generating eligible voters list");


### PR DESCRIPTION
Useful e.g. for https://github.com/w3c-cg/solid/issues/36 as an input to https://github.com/w3c-cg/solid/issues/38.